### PR TITLE
chore: add support for CodeSandbox

### DIFF
--- a/.codesandbox/Dockerfile
+++ b/.codesandbox/Dockerfile
@@ -1,0 +1,1 @@
+FROM node:18-bullseye

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Use [`expo-router`](https://expo.github.io/router) to build universally responsi
 
 Check out the [web demo here](https://expo-instagram-layout.netlify.app/). Pull the app and run in Expo Go to see the results on native.
 
+Check out [this sandbox](https://codesandbox.io/p/sandbox/github/EvanBacon/expo-router-instagram-layout) to edit the code inside your browser.
+
 ### Responsive
 
 A tab navigator that works well in landscape or portrait mode, same code used across web and native.


### PR DESCRIPTION
Allows you to open the repository in CodeSandbox 😇 

<img width="1646" alt="Screenshot 2023-05-15 at 15 01 58" src="https://github.com/EvanBacon/expo-router-instagram-layout/assets/587016/aaaae25a-c3d4-434a-9fe3-b6d7a8034f4c">

The sandbox will stay up to date with the repo, and people can fork it as a template to play with it. It uses snapshotting to ensure that people don't have to wait for yarn install or metro build.

Feel free to close if you're not interested right now!

Looks like this (in my branch): https://codesandbox.io/p/github/EvanBacon/expo-router-instagram-layout/csb-hbfcfv/draft/proud-sun